### PR TITLE
[New page] Add scientific publications page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ navbar-links:
   Blog: "blog"
   #Team: "team"
   #Projects: "projects"
+  Papers: "papers"
   Crédit Agricole: "https://www.credit-agricole.com/"
 
 ################
@@ -267,6 +268,8 @@ collections:
       output: true
       permalink: /:collection/:name    
 
+  papers:
+    output: false
 
 # Default YAML values (more information on Jekyll's site)
 defaults:

--- a/_papers/2020_mix_qa.md
+++ b/_papers/2020_mix_qa.md
@@ -1,0 +1,17 @@
+---
+layout: page
+
+title: "MIX : a Multi-task Learning Approach to Solve Open-Domain Question Answering"
+link: "https://arxiv.org/abs/2012.09766"
+status: ""
+conference: ""
+cover-img: ""
+thumbnail-img: ""
+authors: Sofian Chaybouti, Achraf Saghe, Aymen Shabou
+share-title: "MIX : a Multi-task Learning Approach to Solve Open-Domain Question Answering"
+share-description: "https://arxiv.org/abs/2012.09766"
+share-img: ""
+
+github: ""
+# tags: [SOTA]
+---

--- a/_papers/2021_efficient_qa.md
+++ b/_papers/2021_efficient_qa.md
@@ -1,0 +1,17 @@
+---
+layout: page
+
+title: "EfficientQA : a RoBERTa Based Phrase-Indexed Question-Answering System"
+link: "https://arxiv.org/abs/2101.02157"
+status: ""
+conference: ""
+cover-img: ""
+thumbnail-img: ""
+authors: Sofian Chaybouti, Achraf Saghe, Aymen Shabou
+share-title: "EfficientQA : a RoBERTa Based Phrase-Indexed Question-Answering System"
+share-description: "https://arxiv.org/abs/2101.02157"
+share-img: ""
+
+github: ""
+# tags: [SOTA]
+---

--- a/_papers/2021_visual_wordgrid.md
+++ b/_papers/2021_visual_wordgrid.md
@@ -1,0 +1,17 @@
+---
+layout: page
+
+title: "VisualWordGrid: Information Extraction From Scanned Documents Using A Multimodal Approach"
+link: "https://arxiv.org/abs/2010.02358"
+status: "Accepted"
+conference: "ICDAR, 2021"
+cover-img: ""
+thumbnail-img: ""
+authors: Mohamed Kerroumi, Othmane Sayem, Aymen Shabou
+share-title: "VisualWordGrid: Information Extraction From Scanned Documents Using A Multimodal Approach"
+share-description: "https://arxiv.org/abs/2010.02358"
+share-img: ""
+
+github: ""
+# tags: [SOTA]
+---

--- a/_papers/2023_adversarial_robustness.md
+++ b/_papers/2023_adversarial_robustness.md
@@ -1,0 +1,17 @@
+---
+layout: page
+
+title: "Evaluating Adversarial Robustness on Document Image Classification"
+link: "https://arxiv.org/abs/2304.12486"
+status: "Accepted"
+conference: "ICDAR, 2023"
+cover-img: ""
+thumbnail-img: ""
+authors: Mohamed Dhouib, Ghassen Bettaieb, Aymen Shabou
+share-title: "Evaluating Adversarial Robustness on Document Image Classification"
+share-description: "https://arxiv.org/abs/2304.12486"
+share-img: ""
+
+github: ""
+# tags: [SOTA]
+---

--- a/_papers/2023_doc_parser.md
+++ b/_papers/2023_doc_parser.md
@@ -1,0 +1,17 @@
+---
+layout: page
+
+title: "DocParser: End-to-end OCR-free Information Extraction from Visually Rich Documents"
+link: "https://arxiv.org/abs/2304.12484"
+status: "Accepted"
+conference: "ICDAR, 2023"
+cover-img: ""
+thumbnail-img: ""
+authors: Timothée Fronteau, Arnaud Paran, Aymen Shabou
+share-title: "DocParser: End-to-end OCR-free Information Extraction from Visually Rich Documents"
+share-description: "https://arxiv.org/abs/2304.12484"
+share-img: ""
+
+github: ""
+# tags: [SOTA]
+---

--- a/papers.html
+++ b/papers.html
@@ -5,6 +5,7 @@ hide-title: true
 
 share-title: DataLab Groupe - Papers
 share-description: Learn more about our scientific publications at DataLab Groupe CASA.
+cover-img: "/assets/img/fond-ca.jpg"
 ---
 
 

--- a/papers.html
+++ b/papers.html
@@ -1,0 +1,105 @@
+---
+layout: page
+title: Publications
+hide-title: true
+
+share-title: DataLab Groupe - Papers
+share-description: Learn more about our scientific publications at DataLab Groupe CASA.
+---
+
+
+<!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
+<ul class="posts-list list-unstyled" role="list">
+  {% for paper in site.papers reversed %}
+  <li class="post-preview">
+    <article>
+
+      {%- capture thumbnail -%}
+        {% if paper.thumbnail-img %}
+          {{ paper.thumbnail-img }}
+        {% elsif paper.cover-img %}
+          {% if paper.cover-img.first %}
+            {{ paper.cover-img[0].first.first }}
+          {% else %}
+            {{ paper.cover-img }}
+          {% endif %}
+        {% else %}
+        {% endif %}
+      {% endcapture %}
+      {% assign thumbnail=thumbnail | strip %}
+
+      {% if site.feed_show_excerpt == false %}
+      {% if thumbnail != "" %}
+        <div class="post-image post-image-normal">
+            <!-- <a href="{{ project.url | absolute_url }}" aria-label="Thumbnail"> -->
+            <a href="{{ site.link }}" aria-label="Thumbnail">
+            <img src="{{ thumbnail | absolute_url }}" alt="Project thumbnail">
+            </a>
+        </div>
+      {% endif %}
+      {% endif %}
+
+        <a href="{{ paper.link | absolute_url }}">
+            <h2 class="post-title">{{ paper.title | strip_html }}</h2>
+
+            {% if paper.authors %}
+            <h3 class="post-subtitle">
+            {{ paper.authors | strip_html }}
+            </h3>
+            {% endif %}
+        </a>
+
+        {% if paper.status != "" %}
+            <h3 class="post-subtitle">
+                {% if paper.conference != "" %}
+                    {{ paper.status | append: ' at ' | append: paper.conference }}
+                {% endif %}
+            </h3>
+        {% endif %}
+
+      {% if thumbnail != "" %}
+      <div class="post-image post-image-small">
+        <!-- <a href="{{ project.url | absolute_url }}" aria-label="Thumbnail"> -->
+        <a href="https://github.com/DataLab-Groupe" aria-label="Thumbnail">
+          <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+        </a>
+      </div>
+      {% endif %}
+
+      {% unless site.feed_show_excerpt == false %}
+      {% if thumbnail != "" %}
+      <div class="post-image post-image-short">
+        <!-- <a href="{{ project.url | absolute_url }}" aria-label="Thumbnail"> -->
+        <a href="https://github.com/DataLab-Groupe" aria-label="Thumbnail">
+          <img src="{{ thumbnail | absolute_url }}" alt="Post thumbnail">
+        </a>
+      </div>
+      {% endif %}
+
+      <div class="post-entry">
+        <!-- {% assign excerpt_length = site.excerpt_length | default: 50 %} -->
+        <p style="text-align: justify;">{{ paper.excerpt | strip_html }}</p>
+        <!-- {% if project.content != project.excerpt or excerpt_word_count > excerpt_length %}
+          <a href="{{ project.url | absolute_url }}" class="post-read-more">[Read&nbsp;More]</a>
+        {% endif %} -->
+      </div>
+      {% endunless %}
+
+      {% if site.feed_show_tags != false and paper.tags.size > 0 %}
+      <div class="blog-tags">
+        <span>Tags:</span>
+        <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->
+        <ul class="d-inline list-inline" role="list">
+          {% for tag in paper.tags %}
+          <li class="list-inline-item">
+            <a href="{{ '/tags' | absolute_url }}#{{- tag -}}">{{- tag -}}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+
+    </article>
+  </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
- Added a **"Papers"** page with the currently written scientific publications by the Datalab Groupe (in `_papers` directory)
- Updated `_config.yml` page (`collections` and `navbar-links` attributes)
- `papers.html` contains the layout and Liquid code.

Papers are written in markdown, and sorted (by file name) in the **"Papers"** page.

@ArnaudParan @AYMEN-SHABOU FYI